### PR TITLE
feat: Excluye README del despliegue y añade redirección

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,6 +63,7 @@ jobs:
             **/node_modules/**
             **/documents/**
             **/frontend/**
+            **/README.md
 
       # 3. Creación y Push del Tag de Versión (A5)
       # Este paso se ejecuta solo si el despliegue por FTP fue exitoso.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0;url=/static/index.html">
+</head>
+<body>
+    <p>If you are not redirected automatically, follow this <a href="/static/index.html">link to the application</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
- Modifica el workflow de despliegue en `.github/workflows/deploy.yaml` para excluir el archivo `README.md` de la subida por FTP.
- Crea un archivo `index.html` en la raíz del proyecto que redirige automáticamente a la aplicación de Angular en `/static/index.html`.