### PR TITLE
fix: Corrige la página en blanco configurando base-href

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,7 +31,7 @@ jobs:
         run: npm install --prefix frontend
 
       - name: 4. Build Angular Application
-        run: npm run build --prefix frontend
+        run: npm run build --prefix frontend -- --base-href /static/
 
       - name: 5. Generate .env file with Secrets
         run: |
@@ -63,6 +63,7 @@ jobs:
             **/node_modules/**
             **/documents/**
             **/frontend/**
+            **/README.md
 
       # 3. Creación y Push del Tag de Versión (A5)
       # Este paso se ejecuta solo si el despliegue por FTP fue exitoso.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0;url=/static/index.html">
+</head>
+<body>
+    <p>If you are not redirected automatically, follow this <a href="/static/index.html">link to the application</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
- Actualiza el comando de compilación de Angular en `.github/workflows/deploy.yaml` para incluir el parámetro `--base-href /static/`.
- Esto asegura que la aplicación de Angular pueda encontrar sus recursos (JS, CSS) cuando se sirve desde el subdirectorio `/static`, solucionando el problema de la página en blanco.