### PR TITLE
feat: Add Docker and Docker Compose for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Usar una imagen oficial de PHP con Apache
+FROM php:8.2-apache
+
+# Instalar las extensiones de PHP necesarias
+# pdo_mysql para la conexión con MySQL
+RUN docker-php-ext-install pdo_mysql
+
+# Habilitar el módulo rewrite de Apache para URLs amigables
+RUN a2enmod rewrite
+
+# Copiar el código de la aplicación al directorio web de Apache
+COPY . /var/www/html/
+
+# Establecer los permisos correctos para los archivos de la aplicación
+RUN chown -R www-data:www-data /var/www/html && chmod -R 755 /var/www/html
+
+# Exponer el puerto 80 para el servidor web Apache
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+version: '3.8'
+
+services:
+  # Servicio de la aplicación PHP con Apache
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: php-apache-app
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    environment:
+      - DB_HOST=db
+      - DB_NAME=easyapp_db
+      - DB_USER=user
+      - DB_PASS=password
+    depends_on:
+      - db
+    networks:
+      - app-network
+
+  # Servicio de la Base de Datos MySQL
+  db:
+    image: mysql:8.0
+    container_name: mysql-db
+    restart: always
+    environment:
+      MYSQL_DATABASE: easyapp_db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: root_password
+    volumes:
+      - db-data:/var/lib/mysql
+    networks:
+      - app-network
+
+  # Servicio de phpMyAdmin para gestionar la base de datos
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin-ui
+    restart: always
+    ports:
+      - "8081:80"
+    environment:
+      PMA_HOST: db
+      PMA_PORT: 3306
+      MYSQL_ROOT_PASSWORD: root_password
+    depends_on:
+      - db
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  db-data:
+    driver: local


### PR DESCRIPTION
This commit introduces a Docker-based local development environment for the PHP application.

- A `Dockerfile` is added to create a container with PHP 8.2-apache, the `pdo_mysql` extension, and `mod_rewrite` enabled.
- A `docker-compose.yml` file is added to orchestrate the application (`web`), database (`db`), and `phpmyadmin` services.

This setup allows for a consistent and isolated LAMP-stack environment for local testing and development.