### PR TITLE
feat: Implement secure auth and user registration

### DIFF
--- a/backend/api/index.php
+++ b/backend/api/index.php
@@ -18,6 +18,7 @@ $path = $_SERVER['REQUEST_URI'] ?? '/';
 $routes = [
     'POST' => [
         '/api/v1/auth/login' => [AuthController::class, 'login'],
+        '/api/v1/auth/register' => [AuthController::class, 'register'],
         '/api/v1/requests' => [RequestController::class, 'createRequest'],
         '/api/v1/requests/correct-data' => [RequestController::class, 'correctData'],
     ],

--- a/backend/app/Repositories/AdminRepository.php
+++ b/backend/app/Repositories/AdminRepository.php
@@ -60,4 +60,39 @@ class AdminRepository
 
         return null;
     }
+
+    /**
+     * Creates a new administrator in the database.
+     *
+     * @param string $username The admin's username.
+     * @param string $passwordHash The hashed password.
+     * @param string $name The admin's name.
+     * @return Admin|null The created Admin object on success, null on failure.
+     */
+    public function create(string $username, string $passwordHash, string $name): ?Admin
+    {
+        if ($this->db === null) {
+            error_log('AdminRepository Error: Database connection is not available.');
+            return null;
+        }
+
+        $sql = "INSERT INTO admins (usuario, password_hash, nombre) VALUES (:usuario, :password_hash, :nombre)";
+
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindValue(':usuario', $username, PDO::PARAM_STR);
+            $stmt->bindValue(':password_hash', $passwordHash, PDO::PARAM_STR);
+            $stmt->bindValue(':nombre', $name, PDO::PARAM_STR);
+
+            if ($stmt->execute()) {
+                $id = $this->db->lastInsertId();
+                return new Admin($username, $passwordHash, $name, (int)$id);
+            }
+        } catch (PDOException $e) {
+            // Log the error, especially for unique constraint violations
+            error_log('AdminRepository Error - create: ' . $e->getMessage());
+        }
+
+        return null;
+    }
 }

--- a/backend/app/Services/AuthService.php
+++ b/backend/app/Services/AuthService.php
@@ -25,10 +25,53 @@ class AuthService
     {
         $admin = $this->adminRepository->findByUsername($username);
 
-        if ($admin && password_verify($password, $admin->getPasswordHash())) {
+        if (!$admin) {
+            return null; // User not found
+        }
+
+        // --- Password Decoding Logic ---
+        $sharedSecret = 'my-super-secret-key';
+
+        // 1. Decode the Base64 string
+        $decoded_password_parts = explode(':', base64_decode($password, true), 2);
+
+        // 2. Check if decoding was successful and the secret matches
+        if (count($decoded_password_parts) !== 2 || $decoded_password_parts[0] !== $sharedSecret) {
+            // If the secret is wrong or the format is incorrect, fail authentication
+            return null;
+        }
+
+        // 3. Get the plain-text password
+        $plainPassword = $decoded_password_parts[1];
+        // --- End of Decoding Logic ---
+
+        // 4. Verify the decoded password against the stored hash
+        if (password_verify($plainPassword, $admin->getPasswordHash())) {
             return $admin;
         }
 
         return null;
+    }
+
+    /**
+     * Registers a new administrator.
+     *
+     * @param string $username
+     * @param string $password
+     * @param string $name
+     * @return Admin|null
+     */
+    public function register(string $username, string $password, string $name): ?Admin
+    {
+        // Hash the password for secure storage
+        $passwordHash = password_hash($password, PASSWORD_DEFAULT);
+
+        if (!$passwordHash) {
+            // Password hashing failed
+            return null;
+        }
+
+        // Attempt to create the user in the database
+        return $this->adminRepository->create($username, $passwordHash, $name);
     }
 }

--- a/frontend/src/app/auth/components/login/login.component.ts
+++ b/frontend/src/app/auth/components/login/login.component.ts
@@ -37,7 +37,20 @@ export class LoginComponent implements OnInit {
     this.isSubmitting = true;
     this.loginError = null;
 
-    this.authService.login(this.loginForm.value).subscribe({
+    const credentials = { ...this.loginForm.value };
+    const sharedSecret = 'my-super-secret-key'; // As requested, a shared key.
+
+    // Encode the password using Base64 with the shared secret
+    try {
+      credentials.password = btoa(`${sharedSecret}:${credentials.password}`);
+    } catch (e) {
+      console.error('Failed to encode password:', e);
+      this.loginError = 'An unexpected error occurred during login.';
+      this.isSubmitting = false;
+      return;
+    }
+
+    this.authService.login(credentials).subscribe({
       next: (response) => {
         console.log('Login successful!', response);
         // In a real app, we would save the auth token here


### PR DESCRIPTION
- Adds a new endpoint `/api/v1/auth/register` to allow new administrator registration. The endpoint securely hashes the password using `password_hash` before storing it in the database.
- Modifies the login process to encode the password on the frontend using Base64 with a shared secret, as requested by the user.
- Updates the backend `login` method to decode the password and verify it against the stored hash.